### PR TITLE
Update shouldRefreshMembers

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackChannel.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackChannel.java
@@ -129,7 +129,7 @@ public class SlackChannel {
     }
 
     private boolean shouldRefreshMembers() {
-        return getType().equals(SlackChannelType.PUBLIC_CHANNEL) &&
+        return getType() != SlackChannelType.INSTANT_MESSAGING &&
             (membersLastUpdated == null || LocalDateTime.now().isAfter(membersLastUpdated.plusSeconds(REFRESH_MEMBERS_EVERY_SECONDS)));
     }
 }


### PR DESCRIPTION
Current the rtm.start on connect doesn't return everyone since the result is truncated. So, we need to refresh the channel list after startup for private channels as well